### PR TITLE
ECMS-7566 : add a content in the ITHIT script tag to make sure it is generated as a non-self cloging tag (which is not well supported by browsers)

### DIFF
--- a/webapp/src/main/java/UIOpenDocumentPortlet.java
+++ b/webapp/src/main/java/UIOpenDocumentPortlet.java
@@ -21,6 +21,7 @@ public class UIOpenDocumentPortlet extends GenericPortlet {
     Element script = response.createElement("script");
     script.setAttribute("type", "text/javascript");
     script.setAttribute("src", request.getContextPath()+"/js/ITHitWebDAVClient.js");
+    script.setTextContent("ITHIT");
     response.addProperty(MimeResponse.MARKUP_HEAD_ELEMENT, script);
   }
 


### PR DESCRIPTION
For some reasons, in JBoss the script tag which imports ITHIT lib is added as a self-closing tag (whereas it is added as a non-self closing tag with Tomcat). And browsers does not support well self-closing script tags.
This PR adds a simple content in the script tag to make sure it is rendered as a non-self closing tag.